### PR TITLE
Use ssl when using https urls

### DIFF
--- a/lib/scorm_cloud/base.rb
+++ b/lib/scorm_cloud/base.rb
@@ -28,7 +28,9 @@ module ScormCloud
 			File.open(path) do |f|
   				req = Net::HTTP::Post::Multipart.new "#{url.path}?#{url.query}",
     				"file" => UploadIO.new(f, "application/zip", "scorm.zip")
-  				res = Net::HTTP.start(url.host, url.port) do |http|
+          request = Net::HTTP.new(url.host, url.port)
+          request.use_ssl = true if uri.scheme == 'https'
+          res = request.start do |http|
     				http.request(req)
   				end
   				body = res.body


### PR DESCRIPTION
This should fix the issue we've been seeing in CourseManager that prevents the uploading/viewing of SCORM components over ssl/https.